### PR TITLE
Bump version to 0.12.1

### DIFF
--- a/hashy/__version__.py
+++ b/hashy/__version__.py
@@ -1,7 +1,7 @@
 __application_name__ = "hashy"
 __title__ = __application_name__
 __author__ = "abel"
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 __author_email__ = "j@abel.co"
 __url__ = "https://github.com/jamesabel/hashy"
 __download_url__ = "https://github.com/jamesabel/hashy"


### PR DESCRIPTION
Patch bump for a PyPI release that publishes the new `setup.py` metadata (python_requires, classifiers, Python 3.14), so the PyPI-driven README badges (Python versions, license) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)