### PR TITLE
Make cachy cache_life resolvable at call time

### DIFF
--- a/hashy/__version__.py
+++ b/hashy/__version__.py
@@ -1,7 +1,7 @@
 __application_name__ = "hashy"
 __title__ = __application_name__
 __author__ = "abel"
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 __author_email__ = "j@abel.co"
 __url__ = "https://github.com/jamesabel/hashy"
 __download_url__ = "https://github.com/jamesabel/hashy"

--- a/hashy/cache.py
+++ b/hashy/cache.py
@@ -174,7 +174,7 @@ class _CachyCache:
         self,
         func: Callable,
         cache_dir: Path,
-        cache_life: Optional[timedelta],
+        cache_life: Union[timedelta, Callable[[], Optional[timedelta]], None],
         cache_none: bool,
         in_memory: bool,
         max_cache_size: Union[int, Callable, None],
@@ -294,7 +294,8 @@ class _CachyCache:
             row_metadata = None
             write_ts = 0.0  # force a cache miss
 
-        if self.cache_life is not None and time.time() - write_ts >= self.cache_life.total_seconds():
+        cache_life = self.cache_life() if callable(self.cache_life) else self.cache_life
+        if cache_life is not None and time.time() - write_ts >= cache_life.total_seconds():
             self._expire_entry(metadata_db, key)
 
         # Refresh the LRU read time on access (only relevant when size-bounded).
@@ -304,7 +305,7 @@ class _CachyCache:
             metadata_db.commit()
 
     def _expire_entry(self, metadata_db: CachyDBDict, key: str) -> None:
-        """Delete an expired entry's metadata and payload."""
+        """Delete an expired entry's metadata, payload, and in-memory copy."""
         if key in metadata_db:
             _cache_counters.cache_expired_counter += 1
             del metadata_db[key]
@@ -313,6 +314,9 @@ class _CachyCache:
             if key in db:
                 del db[key]
                 db.commit()
+        # Drop the in-memory copy too, otherwise _read_memory would serve the expired value.
+        if self.in_memory:
+            self.in_memory_cache.pop(key, None)
 
     # -- reads -------------------------------------------------------------
 
@@ -454,11 +458,15 @@ class _CachyCache:
 
 
 def cachy(
-    cache_life: Union[timedelta, None] = None, cache_dir: Path = get_cache_dir(), cache_none: bool = False, in_memory: bool = False, max_cache_size: int | Callable | None = None
+    cache_life: Union[timedelta, Callable[[], Optional[timedelta]], None] = None,
+    cache_dir: Path = get_cache_dir(),
+    cache_none: bool = False,
+    in_memory: bool = False,
+    max_cache_size: int | Callable | None = None,
 ) -> Callable:
     """
     Decorator to persistently cache the results of a function call, with a cache life.
-    :param cache_life: Cache life.
+    :param cache_life: Cache life, as a timedelta or a callable returning the current timedelta (resolved live on each call) or None.
     :param cache_dir: Cache directory.
     :param cache_none: Cache None results (default is to not cache None results).
     :param in_memory: If True, use an in-memory cache for reads (default is to only use a file-based cache).

--- a/test_hashy/test_cachy.py
+++ b/test_hashy/test_cachy.py
@@ -35,6 +35,63 @@ def test_a_cachy_zero_life():
     assert get_counters() == CacheCounters(cache_memory_hit_counter=0, cache_hit_counter=0, cache_miss_counter=2, cache_expired_counter=1, cache_eviction_counter=0)
 
 
+def test_cachy_callable_cache_life():
+
+    clear_counters()
+
+    # cache_life is resolved live on each call, so changing the global afterward takes effect
+    current_cache_life = {"value": timedelta(days=1)}
+
+    @cachy(lambda: current_cache_life["value"], get_cache_directory())
+    def cachy_callable_life_func(p):
+        return p
+
+    func = cachy_callable_life_func
+    # delete the DB so the cache counts are correct
+    for stale in get_cache_directory().glob("cachy_callable_life_func*"):
+        stale.unlink(missing_ok=True)
+
+    # first call misses and caches
+    assert func(1) == 1
+    assert get_counters() == CacheCounters(cache_memory_hit_counter=0, cache_hit_counter=0, cache_miss_counter=1, cache_expired_counter=0, cache_eviction_counter=0)
+    # still fresh under the long life -> hit
+    assert func(1) == 1
+    assert get_counters() == CacheCounters(cache_memory_hit_counter=0, cache_hit_counter=1, cache_miss_counter=1, cache_expired_counter=0, cache_eviction_counter=0)
+
+    # shrink the life to zero -> the next call re-reads the callable and expires the entry
+    current_cache_life["value"] = timedelta(seconds=0)
+    assert func(1) == 1
+    assert get_counters() == CacheCounters(cache_memory_hit_counter=0, cache_hit_counter=1, cache_miss_counter=2, cache_expired_counter=1, cache_eviction_counter=0)
+
+
+def test_cachy_in_memory_expiry():
+
+    clear_counters()
+
+    current_cache_life = {"value": timedelta(days=1)}
+
+    @cachy(lambda: current_cache_life["value"], get_cache_directory(), in_memory=True)
+    def cachy_in_memory_expiry_func(p):
+        return p
+
+    func = cachy_in_memory_expiry_func
+    # delete the DB so the cache counts are correct
+    for stale in get_cache_directory().glob("cachy_in_memory_expiry_func*"):
+        stale.unlink(missing_ok=True)
+
+    # first call misses and caches (in memory + on disk)
+    assert func(1) == 1
+    assert get_counters() == CacheCounters(cache_memory_hit_counter=0, cache_hit_counter=0, cache_miss_counter=1, cache_expired_counter=0, cache_eviction_counter=0)
+    # still fresh -> in-memory hit
+    assert func(1) == 1
+    assert get_counters() == CacheCounters(cache_memory_hit_counter=1, cache_hit_counter=1, cache_miss_counter=1, cache_expired_counter=0, cache_eviction_counter=0)
+
+    # shrink the life to zero -> expiry must evict the in-memory copy too, so the next call is a miss
+    current_cache_life["value"] = timedelta(seconds=0)
+    assert func(1) == 1
+    assert get_counters() == CacheCounters(cache_memory_hit_counter=1, cache_hit_counter=1, cache_miss_counter=2, cache_expired_counter=1, cache_eviction_counter=0)
+
+
 def test_cachy_simple():
 
     @cachy(cache_life, get_cache_directory())


### PR DESCRIPTION
## What

Make `cachy`'s `cache_life` resolvable at call time.

`cache_life` now accepts a callable returning a `timedelta` (or `None`), in addition to a plain `timedelta`/`None`. The value is resolved live on every call instead of being frozen at decoration (import) time — mirroring the pattern already used for `max_cache_size`. This lets a caller pass a getter (e.g. `@cachy(get_cache_life, ...)`) so that changing the configured life afterward actually takes effect.

## Changes

- `_CachyCache.__init__` and the `cachy()` factory widen `cache_life` to `Union[timedelta, Callable[[], Optional[timedelta]], None]`.
- The expiry check (`_expire_and_touch_once`) resolves the callable each call.
- `_uses_metadata` is unchanged — a callable is `not None`, so the write-timestamp metadata table keeps being maintained (required for expiry).
- Fix in-memory expiry: `_expire_entry` now also drops the in-memory copy (`self.in_memory_cache.pop(key, None)`), so an expired entry can't be served from the in-memory dict by `_read_memory`.
- Bump version `0.12.1` → `0.13.0`.

## Tests

- `test_cachy_callable_cache_life` — callable life resolved live (file cache): shrinking the life to zero expires the entry on the next call.
- `test_cachy_in_memory_expiry` — same with `in_memory=True`, confirming the in-memory copy is evicted too.

Full suite: 38 passed. `mypy -m hashy` and flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
