### PR TITLE
Support default arguments in cachy cache keys

### DIFF
--- a/hashy/__version__.py
+++ b/hashy/__version__.py
@@ -1,7 +1,7 @@
 __application_name__ = "hashy"
 __title__ = __application_name__
 __author__ = "abel"
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 __author_email__ = "j@abel.co"
 __url__ = "https://github.com/jamesabel/hashy"
 __download_url__ = "https://github.com/jamesabel/hashy"

--- a/hashy/cache.py
+++ b/hashy/cache.py
@@ -23,6 +23,7 @@ from functools import wraps
 from pathlib import Path
 from datetime import timedelta
 from logging import getLogger
+import inspect
 import time
 import sqlite3
 import pickle
@@ -181,6 +182,14 @@ class _CachyCache:
     ):
         self.func = func
         self.function_name = func.__name__
+        # Used to resolve default argument values when building the cache key, so a
+        # call relying on a default keys the same as one passing that value explicitly.
+        try:
+            self.signature: Optional[inspect.Signature] = inspect.signature(func)
+        except (ValueError, TypeError):
+            # Some callables (e.g. certain builtins) expose no signature; fall back to
+            # keying on the explicitly-passed arguments only.
+            self.signature = None
         self.cache_life = cache_life
         self.cache_none = cache_none
         self.in_memory = in_memory
@@ -225,10 +234,35 @@ class _CachyCache:
         """True when a metadata table is needed (for expiry and/or LRU eviction)."""
         return self.cache_life is not None or self.max_cache_size is not None
 
-    @staticmethod
-    def _key(args: tuple, kwargs: dict) -> str:
-        """Build a stable cache key from the call arguments via hashy's dict/list/set hashing."""
+    def _key(self, args: tuple, kwargs: dict) -> str:
+        """
+        Build a stable cache key from the call arguments via hashy's dict/list/set hashing.
+
+        Default argument values are resolved from the function signature first, so a
+        call that relies on a default participates in the key the same way an explicit
+        value would. Without this, defaults never appear in ``args``/``kwargs`` and two
+        calls with different effective defaults would collide on the same (empty) key.
+        """
+        args, kwargs = self._resolve_defaults(args, kwargs)
         return get_dls_sha512([get_dls_sha512(list(args)), get_dls_sha512(kwargs)])
+
+    def _resolve_defaults(self, args: tuple, kwargs: dict) -> tuple:
+        """
+        Normalize ``(args, kwargs)`` by filling in the function's default values.
+
+        Returns the bound positional/keyword arguments with defaults applied. If the
+        function has no introspectable signature, or the call does not match it, the
+        original ``args``/``kwargs`` are returned unchanged.
+        """
+        if self.signature is None:
+            return args, kwargs
+        try:
+            bound = self.signature.bind(*args, **kwargs)
+        except TypeError:
+            # Arguments don't fit the signature; let the real call raise and key as-is.
+            return args, kwargs
+        bound.apply_defaults()
+        return bound.args, bound.kwargs
 
     def _ensure_cache_dir(self) -> None:
         """Create the cache directory if it does not already exist."""

--- a/test_hashy/test_cachy_default_arguments.py
+++ b/test_hashy/test_cachy_default_arguments.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from datetime import timedelta
 import time
-from multiprocessing import Process, Queue
+import multiprocessing
 
 from hashy import cachy
 
@@ -11,16 +11,23 @@ temp_dir = Path("temp", test_name)
 
 cache_life = timedelta(minutes=10)
 
-# should never cache since time.time() will always be different
+# A "spawn" context is used so each worker re-imports this module and freezes its own
+# default (see test docstring). The default platform start method differs -- "fork" on
+# Linux would inherit the parent's single frozen default, defeating the test -- so we
+# pin "spawn" to keep the behavior identical across platforms.
+mp_context = multiprocessing.get_context("spawn")
+
+
 @cachy(cache_life, temp_dir)
 def get_time(t: float = time.time()) -> float:
     return t
 
-class CacheClass(Process):
+
+class CacheClass(mp_context.Process):
 
     def __init__(self):
-        Process.__init__(self)
-        self.queue = Queue()
+        super().__init__()
+        self.queue = mp_context.Queue()
 
     def run(self):
         self.queue.put(get_time())

--- a/test_hashy/test_cachy_default_arguments.py
+++ b/test_hashy/test_cachy_default_arguments.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from datetime import timedelta
+import time
+from multiprocessing import Process, Queue
+
+from hashy import cachy
+
+test_name = "test_cachy_default_arguments"
+
+temp_dir = Path("temp", test_name)
+
+cache_life = timedelta(minutes=10)
+
+# should never cache since time.time() will always be different
+@cachy(cache_life, temp_dir)
+def get_time(t: float = time.time()) -> float:
+    return t
+
+class CacheClass(Process):
+
+    def __init__(self):
+        Process.__init__(self)
+        self.queue = Queue()
+
+    def run(self):
+        self.queue.put(get_time())
+
+    def get(self):
+        return self.queue.get()
+
+
+def test_cachy_default_arguments():
+    """
+    Default argument values must participate in the cache key.
+
+    ``get_time`` has a default ``t=time.time()`` that is evaluated once per module
+    import. Each spawned process re-imports the module and therefore freezes a
+    *different* default. Because the default is never passed explicitly, it does not
+    appear in ``*args``/``**kwargs``; cachy must resolve it from the function
+    signature, otherwise every process would collide on the same (empty-argument) key
+    and read back the first process's cached value.
+
+    So each process should return its own distinct default value.
+    """
+
+    values = []
+    iterations = 10
+    for count in range(iterations):
+        c = CacheClass()
+        c.start()
+        c.join()
+        values.append(c.get())
+        time.sleep(0.001)
+    assert len(values) == iterations
+    # No two processes collided on a shared cache entry: every value is distinct.
+    assert len(set(values)) == iterations


### PR DESCRIPTION
## Problem

`cachy` built its cache key only from explicitly-passed `*args`/`**kwargs`. Default argument values never appear there, so a call relying on a default keyed off *nothing*. Two calls with different effective defaults would collide on the same (empty-argument) key and read back the wrong cached value.

## Fix

Resolve defaults from the function signature before hashing the key:

- Capture `inspect.signature(func)` once at decoration time, with a graceful fallback (`None`) for callables that expose no signature (e.g. some builtins).
- Before building the key, run `signature.bind(*args, **kwargs).apply_defaults()` so a call relying on a default keys identically to one passing that value explicitly. If the arguments don't fit the signature, fall back to the old behavior and let the real call raise.

Side benefit: `f(1)`, `f(a=1)`, and `f()` (when `a` defaults to `1`) now share one cache entry.

## Test

`test_cachy_default_arguments` spawns processes that each freeze a different `t=time.time()` default and asserts every returned value is distinct (no shared-cache collision).

Bumps version to 0.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
