### PR TITLE
Add CRC64NVME hash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ pip install hashy
 
 ## Introduction
 
-hashy provides an md5, sha256 or sha512 for string, file, dict, list and set.
+hashy provides an md5, sha256, sha512 or crc64nvme for string, file, dict, list and set.
 
 String and file hashes are conventional and can be compared to other implementations. For example,
 you can go to an online hash calculator for "a" and get the same hash as hashy generates.
+
+crc64nvme is the CRC-64/NVME checksum (as used by the NVMe specification and AWS S3 object
+integrity checking), returned as a 16-character hex string.
 
 Hashes for complex data types like dict, list and set are specific to hashy.
 

--- a/hashy/__init__.py
+++ b/hashy/__init__.py
@@ -1,6 +1,6 @@
 from .__version__ import __application_name__, __author__, __version__
-from .file_hash import get_file_md5, get_file_sha256, get_file_sha512
-from .string_hash import get_string_md5, get_string_sha256, get_string_sha512
-from .dls_hash import dls_sort, get_dls_md5, get_dls_sha256, get_dls_sha512, convert_serializable_special_cases, json_dumps
-from .bytes import get_bytes_md5, get_bytes_sha512, get_bytes_sha256
+from .file_hash import get_file_md5, get_file_sha256, get_file_sha512, get_file_crc64nvme
+from .string_hash import get_string_md5, get_string_sha256, get_string_sha512, get_string_crc64nvme
+from .dls_hash import dls_sort, get_dls_md5, get_dls_sha256, get_dls_sha512, get_dls_crc64nvme, convert_serializable_special_cases, json_dumps
+from .bytes import get_bytes_md5, get_bytes_sha512, get_bytes_sha256, get_bytes_crc64nvme
 from .cache import cachy, CacheCounters, get_counters

--- a/hashy/__version__.py
+++ b/hashy/__version__.py
@@ -1,7 +1,7 @@
 __application_name__ = "hashy"
 __title__ = __application_name__
 __author__ = "abel"
-__version__ = "0.13.2"
+__version__ = "0.14.0"
 __author_email__ = "j@abel.co"
 __url__ = "https://github.com/jamesabel/hashy"
 __download_url__ = "https://github.com/jamesabel/hashy"

--- a/hashy/_crc64nvme.py
+++ b/hashy/_crc64nvme.py
@@ -1,0 +1,50 @@
+"""
+CRC-64/NVME implementation with a hashlib-style interface.
+
+CRC-64/NVME is the CRC used by the NVMe specification and by AWS S3 (as
+"CRC64NVME") for object integrity checking. Parameters (per the reveng CRC
+catalogue): poly=0xad93d23594c93659, init=0xffffffffffffffff, refin=true,
+refout=true, xorout=0xffffffffffffffff, check("123456789")=0xae8b14860a799888.
+
+``Crc64Nvme`` mimics the small subset of the hashlib interface that
+``_hash_core`` uses (no-arg constructor, ``update``, ``hexdigest``) so the
+string/bytes/file helpers can treat it exactly like ``hashlib.sha256`` et al.
+Pure Python and table-driven; fine for typical use, but much slower than
+hashlib's C implementations on very large inputs.
+"""
+
+_XOR = 0xFFFFFFFFFFFFFFFF
+
+# Bit-reversed (reflected) form of the CRC-64/NVME polynomial 0xad93d23594c93659.
+_REFLECTED_POLY = 0x9A6C9329AC4BC9B5
+
+
+def _make_table() -> list[int]:
+    table = []
+    for byte_value in range(256):
+        crc = byte_value
+        for _ in range(8):
+            crc = ((crc >> 1) ^ _REFLECTED_POLY) if crc & 1 else (crc >> 1)
+        table.append(crc)
+    return table
+
+
+_TABLE = _make_table()
+
+
+class Crc64Nvme:
+    """CRC-64/NVME with a minimal hashlib-like interface (update/hexdigest)."""
+
+    def __init__(self) -> None:
+        self._crc = _XOR  # init value
+
+    def update(self, data: bytes) -> None:
+        crc = self._crc
+        table = _TABLE
+        for byte_value in data:
+            crc = table[(crc ^ byte_value) & 0xFF] ^ (crc >> 8)
+        self._crc = crc
+
+    def hexdigest(self) -> str:
+        """Return the 16-character lower-case hex digest."""
+        return format(self._crc ^ _XOR, "016x")

--- a/hashy/bytes.py
+++ b/hashy/bytes.py
@@ -1,7 +1,8 @@
-"""Conventional md5/sha256/sha512 hashes for in-memory ``bytes`` objects."""
+"""Conventional md5/sha256/sha512/crc64nvme hashes for in-memory ``bytes`` objects."""
 
 import hashlib
 
+from ._crc64nvme import Crc64Nvme
 from ._hash_core import hash_bytes
 
 
@@ -18,3 +19,8 @@ def get_bytes_sha256(b: bytes) -> str:
 def get_bytes_sha512(b: bytes) -> str:
     """Return the sha512 hex digest of ``b``."""
     return hash_bytes(b, hashlib.sha512)
+
+
+def get_bytes_crc64nvme(b: bytes) -> str:
+    """Return the CRC-64/NVME hex digest of ``b``."""
+    return hash_bytes(b, Crc64Nvme)

--- a/hashy/dls_hash.py
+++ b/hashy/dls_hash.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from typing import Callable, Union, Any
 from pathlib import Path
 
-from hashy import get_string_md5, get_string_sha256, get_string_sha512
+from hashy import get_string_md5, get_string_sha256, get_string_sha512, get_string_crc64nvme
 
 
 import json
@@ -103,3 +103,12 @@ def get_dls_sha512(dl: Union[dict, OrderedDict, list, set]) -> str:
     :return: sha512 hash string corresponding to the dl input
     """
     return _dls_hash(dl, get_string_sha512)
+
+
+def get_dls_crc64nvme(dl: Union[dict, OrderedDict, list, set]) -> str:
+    """
+    Given a possibly unordered nested dictionary, set or list, return a consistent hash of it.
+    :param dl: dist or list
+    :return: CRC-64/NVME hash string corresponding to the dl input
+    """
+    return _dls_hash(dl, get_string_crc64nvme)

--- a/hashy/file_hash.py
+++ b/hashy/file_hash.py
@@ -1,5 +1,5 @@
 """
-Conventional md5/sha256/sha512 hashes for files.
+Conventional md5/sha256/sha512/crc64nvme hashes for files.
 
 Files are read and hashed in fixed-size chunks (see ``_hash_core.hash_stream``)
 so that memory use stays constant regardless of file size. The resulting digests
@@ -10,6 +10,7 @@ from pathlib import Path
 import hashlib
 from typing import Callable, Union
 
+from ._crc64nvme import Crc64Nvme
 from ._hash_core import hash_stream
 
 
@@ -26,6 +27,11 @@ def get_file_sha256(file_path: Union[Path, str]) -> str:
 def get_file_sha512(file_path: Union[Path, str]) -> str:
     """Return the sha512 hex digest of the file at ``file_path``."""
     return _hash_file(file_path, hashlib.sha512)
+
+
+def get_file_crc64nvme(file_path: Union[Path, str]) -> str:
+    """Return the CRC-64/NVME hex digest of the file at ``file_path``."""
+    return _hash_file(file_path, Crc64Nvme)
 
 
 def _hash_file(file_path: Union[Path, str], hash_function: Callable) -> str:

--- a/hashy/string_hash.py
+++ b/hashy/string_hash.py
@@ -1,5 +1,5 @@
 """
-Conventional md5/sha256/sha512 hashes for strings.
+Conventional md5/sha256/sha512/crc64nvme hashes for strings.
 
 The string is UTF-8 encoded before hashing, so these digests match those from
 any standard tool (e.g. an online hash calculator) for the same text.
@@ -7,6 +7,7 @@ any standard tool (e.g. an online hash calculator) for the same text.
 
 import hashlib
 
+from ._crc64nvme import Crc64Nvme
 from ._hash_core import hash_bytes
 
 
@@ -23,3 +24,8 @@ def get_string_sha256(s: str) -> str:
 def get_string_sha512(s: str) -> str:
     """Return the sha512 hex digest of ``s`` (UTF-8 encoded)."""
     return hash_bytes(s.encode(), hashlib.sha512)
+
+
+def get_string_crc64nvme(s: str) -> str:
+    """Return the CRC-64/NVME hex digest of ``s`` (UTF-8 encoded)."""
+    return hash_bytes(s.encode(), Crc64Nvme)

--- a/test_hashy/test_bytes.py
+++ b/test_hashy/test_bytes.py
@@ -1,12 +1,14 @@
-from hashy import get_bytes_md5, get_bytes_sha256, get_bytes_sha512
+from hashy import get_bytes_md5, get_bytes_sha256, get_bytes_sha512, get_bytes_crc64nvme
 
 zero_md5 = "93b885adfe0da089cdf634904fd59f71"
 zero_sha256 = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
 zero_sha512 = "b8244d028981d693af7b456af8efa4cad63d282e19ff14942c246e50d9351d22704a802a71c3580b6370de4ceb293c324a8423342557d4e5c38438f0e36910ee"
+zero_crc64nvme = "d5da5047efec8728"
 
 abe1_md5 = "ecfcf68c2eab18a750db426cebd352bf"
 abe1_sha256 = "0663afdbff5f0572ee5b5950731d981e31e7c3a9b669ae5cca69363e5c4ff861"
 abe1_sha512 = "2c5e4c145b810b16426f57b2f3f627c5c1a686b24f576f420570c46099e9b3d2b56663e55473a9e01dc504acbab17897c80c8312c91b54bc28db94e0985d5ff5"
+abe1_crc64nvme = "4f2f1baeb6cddf69"
 
 
 def test_zero_byte():
@@ -14,6 +16,7 @@ def test_zero_byte():
     assert get_bytes_md5(zero) == zero_md5
     assert get_bytes_sha256(zero) == zero_sha256
     assert get_bytes_sha512(zero) == zero_sha512
+    assert get_bytes_crc64nvme(zero) == zero_crc64nvme
 
 
 def test_abe1_byte():
@@ -21,3 +24,4 @@ def test_abe1_byte():
     assert get_bytes_md5(abe1) == abe1_md5
     assert get_bytes_sha256(abe1) == abe1_sha256
     assert get_bytes_sha512(abe1) == abe1_sha512
+    assert get_bytes_crc64nvme(abe1) == abe1_crc64nvme

--- a/test_hashy/test_dls.py
+++ b/test_hashy/test_dls.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 import pytest
 
-from hashy import dls_sort, get_dls_md5, get_dls_sha256, get_dls_sha512, json_dumps
+from hashy import dls_sort, get_dls_md5, get_dls_sha256, get_dls_sha512, get_dls_crc64nvme, json_dumps
 
 
 def test_dl_sort():
@@ -29,6 +29,9 @@ def test_dl_sort():
 
     dict_hash_512 = get_dls_sha512(in_dict)
     assert dict_hash_512 == "a010a6ff0601b3e4cd33ffff6004718b5145302c24960904778bfedc4228521345c8936322ff267e49f321bdc404b3720492ace7434a4669d1896018fa55e285"
+
+    dict_hash_crc64nvme = get_dls_crc64nvme(in_dict)
+    assert dict_hash_crc64nvme == "fc20db81351f3573"
 
 
 def test_enum():
@@ -62,6 +65,9 @@ def test_set_sort():
     x = {"a", "c", "b"}  # set
     y = ["a", "b", "c"]
     md5 = "c29a5747d698b2f95cdfd5ed6502f19d"
+    crc64nvme = "7be8da44096799f6"
     assert dls_sort(x) == dls_sort(y)
     assert get_dls_md5(x) == md5
     assert get_dls_md5(y) == md5
+    assert get_dls_crc64nvme(x) == crc64nvme
+    assert get_dls_crc64nvme(y) == crc64nvme

--- a/test_hashy/test_hashy.py
+++ b/test_hashy/test_hashy.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 
-from hashy import get_string_md5, get_string_sha256, get_string_sha512, get_file_md5, get_file_sha256, get_file_sha512
+from hashy import get_string_md5, get_string_sha256, get_string_sha512, get_string_crc64nvme, get_file_md5, get_file_sha256, get_file_sha512, get_file_crc64nvme
 
 a_md5 = "0cc175b9c0f1b6a831c399e269772661"
 a_sha256 = "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
 a_sha512 = "1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75"
+a_crc64nvme = "8c2f8445b4cbfc3c"
 
 
 def test_file():
@@ -13,6 +14,7 @@ def test_file():
     assert get_file_md5(file_path) == a_md5
     assert get_file_sha256(file_path) == a_sha256
     assert get_file_sha512(file_path) == a_sha512
+    assert get_file_crc64nvme(file_path) == a_crc64nvme
 
 
 def test_string():
@@ -20,3 +22,10 @@ def test_string():
     assert get_string_md5(s) == a_md5
     assert get_string_sha256(s) == a_sha256
     assert get_string_sha512(s) == a_sha512
+    assert get_string_crc64nvme(s) == a_crc64nvme
+
+
+def test_crc64nvme_check_value():
+    # standard CRC check string and its published CRC-64/NVME check value (see the reveng CRC catalogue)
+    assert get_string_crc64nvme("123456789") == "ae8b14860a799888"
+    assert get_string_crc64nvme("") == "0000000000000000"


### PR DESCRIPTION
## Summary

Adds CRC-64/NVME (the checksum used by the NVMe specification and AWS S3 `CRC64NVME` object integrity checking) alongside the existing md5/sha256/sha512 algorithms:

- `get_string_crc64nvme`, `get_bytes_crc64nvme`, `get_file_crc64nvme`, `get_dls_crc64nvme` — all return a 16-character lower-case hex string, consistent with the other digests.
- Implemented as a pure-Python, table-driven hashlib-style class (`hashy/_crc64nvme.py`) that plugs into the existing `_hash_core.hash_bytes`/`hash_stream` helpers — **no new dependencies**.
- Version bumped to 0.14.0.

## Verification

- Matches the published catalogue check value: `"123456789"` → `ae8b14860a799888`.
- Cross-checked the table-driven code against an independent bit-by-bit CRC computation.
- Chunked streaming (file path) verified identical to one-shot hashing.
- Full suite: 40/40 tests pass; mypy and flake8 clean; black unchanged.

## Notes

Pure Python is much slower than hashlib's C digests on very large files; fine for typical use, with `awscrt` as a future upgrade path if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
